### PR TITLE
Communication disconnection timeout implementation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/hbprotocol"]
 	path = src/hbprotocol
-	url = https://github.com/bipropellant/hbprotocol.git
+url=https://github.com/AntumArk/bipropellant-protocol.git

--- a/inc/config.h
+++ b/inc/config.h
@@ -101,6 +101,13 @@
     //#define DEBUG_SERIAL_ASCII
   #endif
 
+// ############################### INPUT ###############################
+  #ifndef INPUT_TIMEOUT
+    #define INPUT_TIMEOUT          200          // time (ms) when to set motor enable=0, if there is no motor input
+  #endif
+//#ifndef HARD_STOP
+  //#define HARD_STOP                    // choice to stop right away or to decrement to zero
+//#endif
 
 // ############################### ENABLE FLASH STORAGE MECHANISM ###############################
 // this includes flasharea.c and flashaccess.c

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,8 +7,8 @@ include_dir = inc
 ;env_default = genericSTM32F103RC
 ;env_default = hoverboard
 ;env_default = control_softwareserial
-;env_default = control_usart2
-env_default = control_usart3
+env_default = control_usart2
+;env_default = control_usart3
 
 
 [env:genericSTM32F103RC]
@@ -161,7 +161,7 @@ build_flags =
     -D USART3_WORDLENGTH=UART_WORDLENGTH_8B       ; UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
     -D SERIAL_USART_IT_BUFFERTYPE='unsigned char' ; char or short
 
-    -D INPUT_TIMEOUT=200
+    -D INPUT_TIMEOUT=2000
     #-D HARD_STOP
 
     -D FLASH_STORAGE

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,11 +4,11 @@
 [platformio]
 include_dir = inc
 
-env_default = genericSTM32F103RC
+;env_default = genericSTM32F103RC
 ;env_default = hoverboard
 ;env_default = control_softwareserial
 ;env_default = control_usart2
-;env_default = control_usart3
+env_default = control_usart3
 
 
 [env:genericSTM32F103RC]
@@ -127,6 +127,9 @@ build_flags =
     -D USART3_WORDLENGTH=UART_WORDLENGTH_8B       ; UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
     -D SERIAL_USART_IT_BUFFERTYPE='unsigned char' ; char or short
 
+    -D INPUT_TIMEOUT=200
+    #-D HARD_STOP
+
     -D FLASH_STORAGE
     -D HALL_INTERRUPTS
 
@@ -158,6 +161,9 @@ build_flags =
     -D USART3_WORDLENGTH=UART_WORDLENGTH_8B       ; UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
     -D SERIAL_USART_IT_BUFFERTYPE='unsigned char' ; char or short
 
+    -D INPUT_TIMEOUT=200
+    #-D HARD_STOP
+
     -D FLASH_STORAGE
     -D HALL_INTERRUPTS
 
@@ -187,6 +193,9 @@ build_flags =
     -D USART3_BAUD=115200                         ; UART baud rate
     -D USART3_WORDLENGTH=UART_WORDLENGTH_8B       ; UART_WORDLENGTH_8B or UART_WORDLENGTH_9B
     -D SERIAL_USART_IT_BUFFERTYPE='unsigned char' ; char or short
+
+    -D INPUT_TIMEOUT=200
+    #-D HARD_STOP
 
     -D FLASH_STORAGE
     -D HALL_INTERRUPTS

--- a/src/main.c
+++ b/src/main.c
@@ -490,6 +490,7 @@ int main(void) {
                     PosnData.wanted_posn_mm[1] = HallData[1].HallPosn_mm;
                     enable = 0;
             #endif
+            input_timeout=0;
         break;
       case CONTROL_TYPE_PWM:
             #ifdef HARD_STOP
@@ -500,6 +501,7 @@ int main(void) {
                     pwms[1] = 0;
                     enable = 0;
             #endif
+            input_timeout=0;
         break;
       case CONTROL_TYPE_SPEED:
             #ifdef HARD_STOP
@@ -510,6 +512,7 @@ int main(void) {
                     SpeedData.wanted_speed_mm_per_sec[1] = 0;
                     enable = 0;
             #endif
+            input_timeout=0;
         break;
       }
     }


### PR DESCRIPTION
I have made that when you disconnect your device from hoverboard, it could either slow down or make hard stop.
Soft stop is enabled by default. Timeout value is configurable, as well as enabling HARD stop. Everything can be changed in either config.h or platformio.ini

This feature is used with Position/Speed/PWM controls and with UART2/UART3/SOft communications. 

Here is demonstration video: 
  https://photos.app.goo.gl/V6zawA2GK3L7XRNs5