### PR TITLE
fix typo in BLDC, commutation switch hysteresis

### DIFF
--- a/src/bldc.c
+++ b/src/bldc.c
@@ -123,7 +123,7 @@ void BldcController_Init(){
   rtP.cf_speedCoef        = (int) coef;
   // base these on 8khz needing 80/70
   rtP.n_commDeacvHi       = BldcControllerParams.commDeacvHi*BldcControllerParams.callFrequency/8000;
-  rtP.n_commAcvLo         = BldcControllerParams.commDeacvHi*BldcControllerParams.callFrequency/8000;
+  rtP.n_commAcvLo         = BldcControllerParams.commAcvLo*BldcControllerParams.callFrequency/8000;
 
 
   char tmp[256];


### PR DESCRIPTION
Looks like a typo to me, probably no big deal, Just no hysteresis when switching between commutation methods.